### PR TITLE
Install ca-certificates in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 FROM node:10-buster-slim
+
+# Make sure ca-certificates is installed so TLS connections can be made.
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y ca-certificates && \
+    apt-get clean
+
 COPY . /opt/eos-activation-server
 WORKDIR /opt/eos-activation-server
 ENV NODE_ENV test


### PR DESCRIPTION
The Debian images that the node images are based on don't include ca-certificates out of the box. That means TLS connections can't be made to Redis or any other service that might be accessed from the container.

https://phabricator.endlessm.com/T35349