### PR TITLE
Don't rethrow errors from promise rejection handlers

### DIFF
--- a/api/activation.js
+++ b/api/activation.js
@@ -67,8 +67,6 @@ const activation = (router, logger) => {
       res.status(500)
          .json({ error: err.toString(),
                  success: false });
-
-      throw err;
     });
   }
 

--- a/api/ping.js
+++ b/api/ping.js
@@ -66,8 +66,6 @@ const ping = (router, logger) => {
       res.status(500)
          .json({ error: err.toString(),
                  success: false });
-
-      throw err;
     });
   }
 


### PR DESCRIPTION
Previously, these two catch() handlers, handling async errors from redis.lpush() (or, in fact, from the success handler that returns a HTTP 200 status code to the client…) would do three things:

1. Log the error
2. Return a HTTP 500 error to the client
3. Rethrow the error

But there is no subsequent catch() handler attached to these promise chains. As a result, the Node runtime logs:

    UnhandledPromiseRejectionWarning: Unhandled promise rejection. This
    error originated either by throwing inside of an async function
    without a catch block, or by rejecting a promise which was not
    handled with .catch(). (rejection id: 1900)

Don't do that then!

https://phabricator.endlessm.com/T34717