### PR TITLE
Update Docker image to Node 22 on Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright © 2016-2024 Endless OS Foundation LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-FROM node:10-buster-slim
+FROM node:22-bookworm-slim
 
 # Make sure ca-certificates is installed so TLS connections can be made.
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/endlessm/eos-activation-server.git"
   },
   "author": "Endless OS Maintainers <maintainers@endlessos.org>",
-  "license": "LGPL-2.1",
+  "license": "GPL-2.0-or-later",
   "bugs": {
     "url": "https://github.com/endlessm/eos-activation-server/issues"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/endlessm/eos-activation-server.git"
   },
-  "author": "Srdjan Grubor <sgnn7@sgnn7.org>",
+  "author": "Endless OS Maintainers <maintainers@endlessos.org>",
   "license": "LGPL-2.1",
   "bugs": {
     "url": "https://github.com/endlessm/eos-activation-server/issues"

--- a/package.json
+++ b/package.json
@@ -19,14 +19,10 @@
   "homepage": "https://github.com/endlessm/eos-activation-server",
   "dependencies": {
     "body-parser": "^1.17.1",
-    "bull": "^3.9.1",
     "express": "^4.15.2",
     "geoip-lite": "^1.2.0",
-    "i18n-iso-countries": "^4.2.0",
     "ioredis": "^4.11.1",
     "jsonschema": "^1.1.0",
-    "soap": "^0.28.0",
-    "uuid": "^3.0.1",
     "winston": "^3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Node 10 and Debian Buster have been unsupported for a distressingly long
time.

As well as being good practice, this also fixes a failure to start the
service with winston v3.14.1, released yesterday.

    /opt/eos-activation-server/node_modules/winston/lib/winston/transports/console.js:24
      _consoleLog = console.log.bind(console);
                  ^
    
    SyntaxError: Unexpected token =

I also removed a number of unused dependencies, and fixed package.json a little.

https://phabricator.endlessm.com/T35607