### PR TITLE
Update mocha to 10.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-datetime": "^1.4.1",
-    "mocha": "^6.1.4",
+    "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.1",
     "sinon": "^7.3.2",
     "supertest": "^4.0.2"


### PR DESCRIPTION
This addresses security vulnerabilities reported by npm audit:

    debug  3.2.0 - 3.2.6
    Regular Expression Denial of Service in debug - https://github.com/advisories/GHSA-gxpj-cx7g-858c
    fix available via `npm audit fix --force`
    Will install mocha@10.7.3, which is a breaking change
    node_modules/mocha/node_modules/debug
      mocha  5.1.0 - 9.2.1
      Depends on vulnerable versions of debug
      Depends on vulnerable versions of minimatch
      Depends on vulnerable versions of yargs-unparser
      node_modules/mocha
    
    flat  <5.0.1
    Severity: critical
    flat vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-2j2x-2gpw-g8fm
    fix available via `npm audit fix --force`
    Will install mocha@10.7.3, which is a breaking change
    node_modules/flat
      yargs-unparser  <=1.6.3
      Depends on vulnerable versions of flat
      node_modules/yargs-unparser
    
    minimatch  <3.0.5
    Severity: high
    minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3
    fix available via `npm audit fix --force`
    Will install mocha@10.7.3, which is a breaking change
    node_modules/minimatch
    
    5 vulnerabilities (1 low, 1 high, 3 critical)

https://phabricator.endlessm.com/T35607
