### PR TITLE
api: Add /health endpoint

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,28 @@
+// Copyright © 2016-2024 Endless OS Foundation LLC
+// SPDX-License-Identifier: GPL-2.0-or-later
+// vim: ts=2 sw=2 expandtab
+'use strict';
+
+// Overridable on import of this module
+let redis;
+
+const health = (router, logger) => {
+  router.get('/health', (req, res) => {
+    redis.incr('healthy').then(() => {
+      res.status(200)
+         .json({ status: 'ok' });
+    }).catch((err) => {
+      res.status(500)
+         .json({ status: 'unhealthy',
+                 error: err.toString() });
+    });
+  });
+
+  return router;
+}
+
+exports = module.exports = (router, redisClient, logger) => {
+  redis = redisClient;
+
+  return health(router, logger);
+};

--- a/api/index.js
+++ b/api/index.js
@@ -9,6 +9,7 @@ const config = require('../config');
 
 const activation = require('./activation');
 const ping = require('./ping');
+const health = require('./health');
 
 const router = express.Router();
 
@@ -17,6 +18,7 @@ const redisBackend = require('../util/redis').getRedis;
 redisBackend((redis) => {
   activation(router, redis, config.logger);
   ping(router, redis, config.logger);
+  health(router, redis, config.logger);
 });
 
 exports = module.exports = {

--- a/healthcheck
+++ b/healthcheck
@@ -8,7 +8,7 @@ var http = require("http");
 var options = {
     host     : config.server_bind_address,
     method   : "GET",
-    path     : "/",
+    path     : "/health",
     port     :  config.server_port,
     timeout  : 5,
 };
@@ -24,7 +24,7 @@ var request = http.request(options, (res) => {
 });
 
 request.on('error', function(err) {
-    console.log('ERROR');
+    console.log('ERROR: %s', err);
     process.exit(1);
 });
 


### PR DESCRIPTION
Previously, the HEALTHCHECK configured in the Dockerfile would just make an HTTP request to / and check that the result code is in the range 200–499. In practice the result code would be 404 because there is no route at the root.

However, this does not actually check whether the service is healthy. The only function of the service is to turn HTTP requests into entries in Redis queues.

Add a new /health route that increments a Redis key. This is done rather than using PING because PING succeeds when we are connected to a read-only replica, but for the service to be healthy it must be able to write to Redis.

Adapt the healthcheck script to hit that endpoint.

https://phabricator.endlessm.com/T32315