### PR TITLE
Allow connecting to Redis with TLS

### DIFF
--- a/api/activation.js
+++ b/api/activation.js
@@ -61,7 +61,7 @@ const activation = (router, logger) => {
       res.status(200)
          .json({ success: true });
     }).catch((err) => {
-      logger.error(err);
+      logger.error('Failed to save activation: ' + err);
 
       res.status(500)
          .json({ error: err.toString(),

--- a/api/ping.js
+++ b/api/ping.js
@@ -60,7 +60,7 @@ const ping = (router, logger) => {
       res.status(200)
          .json({ success: true });
     }).catch((err) => {
-      logger.error(err);
+      logger.error('Failed to save ping: ' + err);
 
       res.status(500)
          .json({ error: err.toString(),

--- a/app.js
+++ b/app.js
@@ -27,18 +27,20 @@ app.use(api.router);
 
 // Error handler
 app.use((err, req, res, next) => {
-  if (err) {
-    logger.error(err);
+  logger.error(err);
 
-    let errorMessage = "Server error";
-    if (process.env.NODE_ENV == 'test') {
-      errorMessage = err.toString() + '\n' + err.stack;
-    }
-
-    res.status(500)
-       .json({ error: errorMessage,
-               success: false });
+  if (res.headersSent) {
+    return next(err);
   }
+
+  let errorMessage = "Server error";
+  if (process.env.NODE_ENV == 'test') {
+    errorMessage = err.stack;
+  }
+
+  res.status(500)
+     .json({ error: errorMessage,
+             success: false });
 });
 
 logger.info('Server starting on ' +

--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ app.use(api.router);
 
 // Error handler
 app.use((err, req, res, next) => {
-  logger.error(err);
+  logger.error(`while handling ${req.method} ${req.url}: ${err}`);
 
   if (res.headersSent) {
     return next(err);

--- a/config/index.js
+++ b/config/index.js
@@ -11,6 +11,7 @@ const server_bind_address = process.env.BIND_ADDRESS || '127.0.0.1';
 const redis_host = process.env.REDIS_HOST || '127.0.0.1';
 const redis_port = parseInt(process.env.REDIS_PORT, 10) || 6379;
 const redis_password = process.env.REDIS_PASSWORD || '';
+const redis_tls = ["true", "1"].includes((process.env.REDIS_TLS || '').toLowerCase());
 
 // Crash handler
 process.on('uncaughtException', (err) => {
@@ -26,4 +27,5 @@ exports = module.exports = {
   redis_host,
   redis_port,
   redis_password,
+  redis_tls,
 };

--- a/config/index.js
+++ b/config/index.js
@@ -14,7 +14,7 @@ const redis_password = process.env.REDIS_PASSWORD || '';
 
 // Crash handler
 process.on('uncaughtException', (err) => {
-  logger.error(err.stack);
+  logger.error(`Uncaught exception: ${err.stack}`);
   process.exit(1);
 });
 

--- a/util/redis.js
+++ b/util/redis.js
@@ -12,10 +12,16 @@ exports = module.exports = {
   redisPort: config.redis_port,
   redisPassword: config.redis_password,
   getRedis: (callback) => {
+    /* ioredis uses tls.connect() if the tls option is set, and passes it as
+     * additional options to tls.connect().
+     */
+    let tls = config.redis_tls ? {} : undefined;
+
     const redis = new Redis({
       host: config.redis_host,
       port: config.redis_port,
       password: config.redis_password,
+      tls,
       reconnectOnError(err) {
         /* Reconnect when ElastiCache has promoted some other node to primary & 
          * demoted the node we are connected to a replica.

--- a/util/redis.js
+++ b/util/redis.js
@@ -42,6 +42,22 @@ exports = module.exports = {
       },
     });
 
+    redis.on('connect', () => {
+      config.logger.info('Connected to Redis server');
+    });
+    redis.on('ready', () => {
+      config.logger.info('Redis connection ready');
+    });
+    redis.on('reconnecting', (delay) => {
+      config.logger.info(`Reconnecting to ${config.redis_host}:${config.redis_port} in ${delay} ms`);
+    });
+    redis.on('close', () => {
+      config.logger.info('Disconnected from Redis server');
+    });
+    redis.on('error', (err) => {
+      config.logger.error('Error connecting to Redis server: ' + err);
+    });
+
     callback(redis);
   },
 };


### PR DESCRIPTION
Previously we've been using a client-side proxy to connect to
our TLS-enabled ElastiCache cluster. But ioredis supports connecting with TLS
natively. There are two ways to opt in:

1. If a connection string is passed to the Redis constructor, using rediss://
   rather than redis:// as the scheme enables TLS.
2. Pass a 'tls' option whose value is a (possibly-empty) object of options to
   pass through to Node's tls.connect() method.

Add a new REDIS_TLS environment variable, which can be set to '1' or 'true' to
connect with TLS. If set, set the 'tls' option to an empty object to enable TLS.

Stacked on top of:

- #10

https://phabricator.endlessm.com/T35672