### PR TITLE
Fix Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,6 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
I misread the following documentation of the `directory` key:

> You define the directory relative to the root of the repository for all
> ecosystems except GitHub Actions.

as meaning that `directory` was optional for the github-actions ecosystem. But in fact it is required there; the documentation clarifies:

> For GitHub Actions, you do not need to set the directory to
> `/.github/workflows`. Configuring the key to `/` automatically instructs
> Dependabot to search the `/.github/workflows` directory, as well as the
> `action.yml` / `action.yaml` file from the root directory.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory