### PR TITLE
redis: Don't resend command after reconnecting due to READONLY

### DIFF
--- a/util/redis.js
+++ b/util/redis.js
@@ -43,7 +43,7 @@ exports = module.exports = {
            * run (typically after 3 hours or after a network change) so it is
            * not imperative to retry on the server.
            */
-          return 2;
+          return 1;
         }
       },
     });


### PR DESCRIPTION
I made a local change to reconnectOnError() to return `2` to test the behaviour. I then described in the comment why I thought that it would be better not to do that, but forgot to change the `2` back to `1` or `true`.

Fixes commit a755997df1e0f654b76db29954816de3be150802.

https://phabricator.endlessm.com/T35146